### PR TITLE
fix composable chain-id

### DIFF
--- a/data/chainData.js
+++ b/data/chainData.js
@@ -400,7 +400,7 @@ export const chainData = [
         hyperLink: "https://sgenetwork.io"
     },
     {
-        chain_id: "centuri-1",
+        chain_id: "centauri-1",
         denom: "ppica",
         displayDenom: "pica",
         base_denom: {

--- a/data/experimentalChain.js
+++ b/data/experimentalChain.js
@@ -489,8 +489,8 @@ export const chainObj = {
             high: 0.5,
         },
     },
-    "centuri-1": {
-        chainId: "centuri-1",
+    "centauri-1": {
+        chainId: "centauri-1",
         chainName: "composable",
         rpc: "https://composable-rpc.polkachu.com/",
         rest: "https://composable-api.polkachu.com/",
@@ -510,7 +510,7 @@ export const chainObj = {
                 coinDenom: "PICA",
                 coinMinimalDenom: "ppica",
                 coinDecimals: 12,
-                coinGeckoId: "banksy-token",
+                coinGeckoId: "picasso",
             },
         ],
         feeCurrencies: [
@@ -518,14 +518,14 @@ export const chainObj = {
                 coinDenom: "PICA",
                 coinMinimalDenom: "ppica",
                 coinDecimals: 12,
-                coinGeckoId: "banksy-token",
+                coinGeckoId: "picasso",
             },
         ],
         stakeCurrency: {
             coinDenom: "PICA",
             coinMinimalDenom: "ppica",
             coinDecimals: 12,
-            coinGeckoId: "banksy-token",
+            coinGeckoId: "picasso",
         },
         gasPriceStep: {
             low: 0.25,


### PR DESCRIPTION
there is a typo in centauri-1 chain id for composable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the chain ID from "centuri-1" to "centauri-1" across relevant data files.
	- Updated associated chain details including chain name and endpoints in `experimentalChain.js`.
	- Modified `coinGeckoId` from "banksy-token" to "picasso" to reflect accurate token identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->